### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-wideband-reference.yaml
+++ b/.github/workflows/update-wideband-reference.yaml
@@ -1,6 +1,8 @@
 # todo: reduce copy-paste with update-libfirmware-reference.yaml
 
 name: Update wideband Reference
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/gerefi/gerefi/security/code-scanning/23](https://github.com/gerefi/gerefi/security/code-scanning/23)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, it needs `contents: write` to commit and push changes to the repository. Other permissions, such as `contents: read`, are implicitly included when `contents: write` is specified. No additional permissions are required.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
